### PR TITLE
chore: update Docker base image to golang:1.21-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.1-alpine3.11 as builder
+FROM golang:1.21-alpine as builder
 EXPOSE 8080
 
 ENV CGO_ENABLED=0


### PR DESCRIPTION
Update from golang:1.14.1-alpine3.11 (2020) to golang:1.21-alpine for security fixes.